### PR TITLE
Multicall2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Utility library to make calls to Ethereum blockchain.
 
-Uses MakerDAO's [Multicall2 contract](https://github.com/makerdao/multicall) to make multiple requests in a single HTTP query. Encodes and decodes data automatically.
+Uses MakerDAO's [Multicall contracts](https://github.com/makerdao/multicall) to make multiple requests in a single HTTP query. Encodes and decodes data automatically.
 
 Inspired and powered by [ethers.js](https://github.com/ethers-io/ethers.js/).
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Utility library to make calls to Ethereum blockchain.
 
-Uses MakerDAO's [Multicall contract](https://github.com/makerdao/multicall) to make multiple requests in a single HTTP query. Encodes and decodes data automatically.
+Uses MakerDAO's [Multicall2 contract](https://github.com/makerdao/multicall) to make multiple requests in a single HTTP query. Encodes and decodes data automatically.
 
 Inspired and powered by [ethers.js](https://github.com/ethers-io/ethers.js/).
 
@@ -14,6 +14,7 @@ npm install ethcall
 
 * `Contract(address, abi)`: create contract instance; calling `contract.call_func_name` will yield a `call` object.
 * `all(calls)`: execute all calls in a single request.
+* `tryAll(calls)`: execute all calls in a single request. Ignores reverted calls and returns `null` value in place of return data.
 * `calls`: list of helper call methods
   * `getEthBalance(address)`: returns account ether balance
 

--- a/src/abi/multicall2.json
+++ b/src/abi/multicall2.json
@@ -1,0 +1,315 @@
+[
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "aggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes[]",
+        "name": "returnData",
+        "type": "bytes[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "blockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "name": "getBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockCoinbase",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "coinbase",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockDifficulty",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "difficulty",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockGasLimit",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "gaslimit",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCurrentBlockTimestamp",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "timestamp",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "addr",
+        "type": "address"
+      }
+    ],
+    "name": "getEthBalance",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "balance",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getLastBlockHash",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryAggregate",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bool",
+        "name": "requireSuccess",
+        "type": "bool"
+      },
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "target",
+            "type": "address"
+          },
+          {
+            "internalType": "bytes",
+            "name": "callData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Call[]",
+        "name": "calls",
+        "type": "tuple[]"
+      }
+    ],
+    "name": "tryBlockAndAggregate",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "blockNumber",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "blockHash",
+        "type": "bytes32"
+      },
+      {
+        "components": [
+          {
+            "internalType": "bool",
+            "name": "success",
+            "type": "bool"
+          },
+          {
+            "internalType": "bytes",
+            "name": "returnData",
+            "type": "bytes"
+          }
+        ],
+        "internalType": "struct Multicall2.Result[]",
+        "name": "returnData",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/call.ts
+++ b/src/call.ts
@@ -2,6 +2,7 @@ import { Contract } from '@ethersproject/contracts';
 import { BaseProvider } from '@ethersproject/providers';
 
 import * as multicallAbi from './abi/multicall.json';
+import * as multicall2Abi from './abi/multicall2.json';
 
 import Abi from './abi';
 
@@ -13,6 +14,11 @@ export interface Call {
 	inputs: any[]
 	outputs: any[];
 	params: any[];
+}
+
+export interface Result {
+	success: boolean;
+	returnData: any;
 }
 
 export async function all(provider: BaseProvider, multicallAddress: string, calls: Call[], block?: number) {
@@ -41,3 +47,36 @@ export async function all(provider: BaseProvider, multicallAddress: string, call
 	}
 	return callResult;
 }
+
+export async function tryAll(provider: BaseProvider, multicall2Address: string, calls: Call[], block?: number) {
+	const multicall2 = new Contract(multicall2Address, multicall2Abi, provider);
+	const callRequests = calls.map(call => {
+		const callData = Abi.encode(call.name, call.inputs, call.params);
+		return {
+			target: call.contract.address,
+			callData,
+		};
+	});
+	const overrides = {
+		blockTag: block,
+	};
+	const response: Result[] = await multicall2.tryAggregate(false, callRequests, overrides);
+	const callCount = calls.length;
+	const callResult = [];
+	for (let i = 0; i < callCount; i++) {
+		const outputs = calls[i].outputs;
+		const result = response[i];
+		if (!result.success) {
+			callResult.push(null);
+		} else {
+			const params = Abi.decode(outputs, result.returnData);
+			const data = outputs.length === 1
+				? params[0]
+				: params;
+			callResult.push(data);
+		}
+	}
+	return callResult;
+}
+
+

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,38 +1,75 @@
 import { BaseProvider } from '@ethersproject/providers';
 
-import { Call, all as callAll } from './call';
+import { Call, all as callAll, tryAll as callTryAll } from './call';
 import { getEthBalance } from './calls';
+
+const DEFAULT_CHAIN_ID = 1;
 
 export default class Provider {
 	provider?: BaseProvider;
 	multicallAddress: string;
+	multicall2Address?: string;
 
 	constructor() {
-		this.multicallAddress = getAddress(1);
+		this.multicallAddress = getAddress(DEFAULT_CHAIN_ID);
+		this.multicall2Address = getMulticall2Address(DEFAULT_CHAIN_ID);
 	}
 
-	async init(provider: BaseProvider) {
-		this.provider = provider;
+	async init(provider: BaseProvider, multicallAddress?: string, multicall2Address?: string) {
 		const network = await provider.getNetwork();
-		this.multicallAddress = getAddress(network.chainId);
+		this.provider = provider;
+		this.multicallAddress = multicallAddress ?? getAddress(network.chainId);
+		this.multicallAddress = multicall2Address ?? getMulticall2Address(network.chainId);
 	}
 
-	getEthBalance(address: string) {
+	/**
+	 * Makes one call to the multicall contract to retrieve eth balance of the given address.
+	 * @param address  Address of the account you want to look up
+	 * @param multicallAddress	Address of the Multicall instance to use
+	 */
+	getEthBalance(address: string, multicallAddress?: string) {
 		if (!this.provider) {
-			console.error('Provider should be initialized before use.');
+			throw Error('Provider should be initialized before use.');
 		}
 		return getEthBalance(address, this.multicallAddress);
 	}
 
+	/**
+	 * Aggregates multiple calls into one call. Reverts when any of the calls fails. For
+	 * ignoring the success of each call, use {@link tryAll} instead.
+	 * @param calls  Array of Call objects containing information about each read call
+	 * @param block  Block number for this call
+	 */
 	async all(calls: Call[], block?: number) {
 		if (!this.provider) {
-			console.error('Provider should be initialized before use.');
+			throw Error('Provider should be initialized before use.');
 		}
 		const provider = this.provider as BaseProvider;
 		return await callAll(provider, this.multicallAddress, calls, block);
 	}
+
+	/**
+	 * Aggregates multiple calls into one call. If any of the calls fail, it returns a null value
+	 * in place of the failed call's return data.
+	 * @param calls  Array of Call objects containing information about each read call
+	 * @param block  Block number for this call
+	 */
+	async tryAll(calls: Call[], block?: number) {
+		if (!this.provider) {
+			throw Error('Provider should be initialized before use.');
+		}
+		if (!this.multicall2Address) {
+			throw Error("Multicall2 address should be initialized before using tryAll()");
+		}
+		const provider = this.provider as BaseProvider;
+		return await callTryAll(provider, this.multicall2Address, calls, block);
+	}
 }
 
+/**
+ * Gets the address of Multicall contract on the network with the given chain ID
+ * @param chainId  Chain ID of the network that has an instance of Multicall contract
+ */
 function getAddress(chainId: number): string {
 	const addressMap: Record<number, string> = {
 		1: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
@@ -43,6 +80,23 @@ function getAddress(chainId: number): string {
 		137: '0x35e4aa226ce52e1e59e5e5ec24766007bcbe2e7d',
 		1337: '0x77dca2c955b15e9de4dbbcf1246b4b85b651e50e',
 	};
-	const address = addressMap[chainId];
-	return address;
+	return addressMap[chainId];
+}
+
+/**
+ * Gets the address of Multicall2 contract on the network with the given chain ID.
+ * For more details on Multicall2, please refer to https://github.com/makerdao/multicall
+ * @param chainId  Chain ID of the network that has an instance of Multicall2 contract
+ */
+function getMulticall2Address(chainId: number): string {
+	const addressMap: Record<number, string> = {
+		1: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+		4: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+		5: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+		42: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+		56: '0x4c6bb7c24b6f3dfdfb548e54b7c5ea4cb52a0069',
+		100: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',
+		137: '0xf43a7be1b284aa908cdfed8b3e286961956b4d2c',
+	};
+	return addressMap[chainId];
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -19,7 +19,7 @@ export default class Provider {
 		this.provider = provider;
 		const network = await provider.getNetwork();
 		this.multicallAddress = getAddress(network.chainId);
-		this.multicallAddress = getMulticall2Address(network.chainId);
+		this.multicall2Address = getMulticall2Address(network.chainId);
 	}
 
 	/**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -15,11 +15,11 @@ export default class Provider {
 		this.multicall2Address = getMulticall2Address(DEFAULT_CHAIN_ID);
 	}
 
-	async init(provider: BaseProvider, multicallAddress?: string, multicall2Address?: string) {
-		const network = await provider.getNetwork();
+	async init(provider: BaseProvider) {
 		this.provider = provider;
-		this.multicallAddress = multicallAddress ?? getAddress(network.chainId);
-		this.multicallAddress = multicall2Address ?? getMulticall2Address(network.chainId);
+		const network = await provider.getNetwork();
+		this.multicallAddress = getAddress(network.chainId);
+		this.multicallAddress = getMulticall2Address(network.chainId);
 	}
 
 	/**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -66,10 +66,6 @@ export default class Provider {
 	}
 }
 
-/**
- * Gets the address of Multicall contract on the network with the given chain ID
- * @param chainId  Chain ID of the network that has an instance of Multicall contract
- */
 function getAddress(chainId: number): string {
 	const addressMap: Record<number, string> = {
 		1: '0xeefba1e63905ef1d7acba5a8513c70307c1ce441',
@@ -83,11 +79,6 @@ function getAddress(chainId: number): string {
 	return addressMap[chainId];
 }
 
-/**
- * Gets the address of Multicall2 contract on the network with the given chain ID.
- * For more details on Multicall2, please refer to https://github.com/makerdao/multicall
- * @param chainId  Chain ID of the network that has an instance of Multicall2 contract
- */
 function getMulticall2Address(chainId: number): string {
 	const addressMap: Record<number, string> = {
 		1: '0x5ba1e12693dc8f9c48aad8770482f4739beed696',


### PR DESCRIPTION
Changes in this PR

Add another set of address map that contains Multicall2 addresses
Add a new method Provider.tryAll which is identical to all except it will ignore any reverted calls (if any) and return null in place of their return values. This call relies on Multicall2 contract instances.
Does not modify existing Provider.all function - it will still use the original Multicall contract instances.
TODO: deploy Multicall2 on chain 56
TODO: mark all read functions as view in ABI file Marked Multicall2.tryAggregate() function as view

Please double check the deployed contracts on sidechains match MakerDAO's repo and MakerDAO's deployment settings on eth mainnet!

Chain 56: https://bscscan.com/address/0x4c6bb7c24b6f3dfdfb548e54b7c5ea4cb52a0069#code
Chain 137: https://polygonscan.com/address/0xf43a7be1b284aa908cdfed8b3e286961956b4d2c#code